### PR TITLE
0.0.5: The "Seasons" Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog - The Football PBP Application
 
+## 0.0.5: The "Seasons" Update
+- Added a prompt that allows one to create a new season within a football league.
+- Added a prompt that allows one to edit a season within an existing football league.
+- Implemented `core.embedded.LettersAndNumbers()`, a class with sets of letters, numbers, and/or characters to make it easier to filter out unwanted characters for prompts/inputs in this app.
+- Re-implemented all internal SQL scripts to no longer use f-strings.
+- Fixed the title within `core.views.edit_league_view.LeagueView` to display `"Edit League..."` instead of `"About"`.
+- Fixed the title within `core.views.edit_league_view.new_league_view` to display `"New League..."` instead of `"About"`.
+- Fixed the title within `core.views.edit_season_view.SeasonView` to display `"Edit Season..."` instead of `"About"`.
+- Fixed an issue within `core.views.edit_league_view.LeagueView` that would allow a user to name a football league with more than the intended 256 characters.
+- Renamed `core.views.main_window_view.main_window()` to `core.views.main_window_view.MainWindow()` to better fit this application's naming scheme with classes and functions.
+- Fixed a bug within `core.views.main_window_view.MainWindow().refresh_league_seasons()` that would result in the `fb_seasons_df` table to not refresh in every situation `core.views.main_window_view.MainWindow().refresh_league_seasons()` was called.
+- Fixed a minor edge case issue in `core.views.main_window_view.MainWindow().refresh_league_seasons()` that would occasionally result in the list of seasons being noticeably out of order.
+- Added `"New League"` and `"New League"` buttons to the main window in `core.views.main_window_view.MainWindow()`.
+- Fixed a minor edge case in `core.views.main_window_view.MainWindow()` where the window would occasionally forget which league you had previously selected when accessing that league's settings.
+- Updated the app version to `0.0.5`
+
 ## 0.0.4a: The "quick fix security" Update
 - Fixed a potential security issue in `core.views.edit_league_view.new_league_view()` caused by unwanted characters being passed in.
 - Fixed a potential security issue in `core.views.edit_league_view.new_league_view()` caused by too many characters being passed in.

--- a/core/other/embedded.py
+++ b/core/other/embedded.py
@@ -1,6 +1,6 @@
 """
 - Creation Date: 2/3/2024 1:18 PM EDT
-- Last Updated: 05/12/2024 05:30 PM EDT
+- Last Updated: 05/18/2024 01:30 AM EDT
 - Authors: Joseph Armstrong (armstrongjoseph08@gmail.com)
 - file: `./resources/embedded.py`
 - Purpose: Holds data that is embedded into this app,
@@ -12,7 +12,7 @@
 class EmbeddedElements:
     def app_version():
         """ """
-        return "0.0.4a"
+        return "0.0.5"
 
     def desktop_icon():
         """ """
@@ -661,3 +661,44 @@ iz7MXFXNT5b771yPwL/bRkLC18+kyqCsAh/BZgodiYdI0ocEmvhSTuW1Ycrp9R/AZwl82l3eF2N0aeLV
 wD6HFmz/AXxMyodSSizTPwQfBxI6Nm17qqWS32vTRH8/C3yaoBelA/s4jX2slOD/A/AessspSzWVAAAA
 AElFTkSuQmCC
         """
+
+
+class LettersAndNumbers:
+    # This is separate, because we don't need a whole entire image reloaded
+    # to access a bunch of letters.
+    def letters_all(include_space: bool = False):
+        phrase = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        if include_space is True:
+            phrase += " "
+        return phrase
+
+    def letters_lower(include_space: bool = False):
+        phrase = "abcdefghijklmnopqrstuvwxyz"
+        if include_space is True:
+            phrase += " "
+        return phrase
+
+    def letters_upper(include_space: bool = False):
+        phrase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        if include_space is True:
+            phrase += " "
+        return phrase
+
+    def numbers_all(include_space: bool = False):
+        phrase = "0123456789"
+        if include_space is True:
+            phrase += " "
+        return phrase
+
+    def letters_and_numbers(include_space: bool = False):
+        phrase = "abcdefghijklmnopqrstuvwxyz"
+        phrase += "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        if include_space is True:
+            phrase += " "
+        return phrase
+
+    def upper_letters_and_numbers(include_space: bool = False):
+        phrase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        if include_space is True:
+            phrase += " "
+        return phrase

--- a/core/views/edit_league_view.py
+++ b/core/views/edit_league_view.py
@@ -1,35 +1,39 @@
 """
 - Creation Date: 03/10/2024 04:35 PM EDT
-- Last Updated: 05/12/2024 05:25 PM EDT
+- Last Updated: 05/18/2024 01:30 AM EDT
 - Authors: Joseph Armstrong (armstrongjoseph08@gmail.com)
 - file: `./core/views/edit_league_view.py`
 - Purpose: Code behind for the window
     that allows a user to view and edit leagues.
 """
 
-from datetime import datetime
 import logging
 import operator
 import sqlite3
+from datetime import datetime
+
 import polars as pl
 import PySimpleGUI as sg
 
 from core.database.load_db_elements import SqliteLoadData
 from core.database.sqlite3_connectors import initialize_sqlite3_connectors
-from core.other.embedded import EmbeddedElements
+from core.other.embedded import EmbeddedElements, LettersAndNumbers
 
 
 class LeagueView:
     """
     Class for handling logic with editing league settings.
     """
-    letters_all = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    letters_lower = "abcdefghijklmnopqrstuvwxyz"
-    letters_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    numbers_all = "0123456789"
-    letters_and_numbers = "abcdefghijklmnopqrstuvwxyz" +\
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    upper_letters_and_numbers = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+    letters_all = LettersAndNumbers.letters_all(include_space=True)
+    letters_lower = LettersAndNumbers.letters_lower()
+    letters_upper = LettersAndNumbers.letters_upper()
+    numbers_all = LettersAndNumbers.numbers_all()
+    letters_and_numbers = LettersAndNumbers.letters_and_numbers(
+        include_space=True
+    )
+    upper_letters_and_numbers = LettersAndNumbers.upper_letters_and_numbers()
+
     # sqlite3 connectors
     sqlite3_con = None
     sqlite3_cur = None
@@ -151,78 +155,142 @@ class LeagueView:
         # by a line being more than 80 characters long.
         kickoff_fc = self.kickoff_fc_always_goes_to_touchback
 
-        sql_script = f"""
+        sql_script = """
         UPDATE fb_leagues
         SET
-            "league_id" = "{self.league_id}",
-            "league_long_name" = "{self.league_long_name}",
-            "league_short_name" = "{self.league_short_name}",
-            "league_notes" = "{self.league_notes}",
-            "field_length" = {self.field_length},
+            "league_id" = ?,
+            "league_long_name" = ?,
+            "league_short_name" = ?,
+            "league_notes" = ?,
+            "field_length" = ?,
 
-            "downs" = {self.downs},
-            "first_down_yards" = {self.first_down_yards},
-            "kickoff_yardline" = {self.kickoff_yardline},
-            "safety_kick_yardline" = {self.safety_kick_yardline},
-            "kickoff_touchback_yardline" = {self.kickoff_touchback_yardline},
-            "punt_touchback_yardline" = {self.punt_touchback_yardline},
-            "normal_touchback_yardline" = {self.normal_touchback_yardline},
-            "kansas_ot_yardline" = {self.kansas_ot_yardline},
-            "pat_yardline" = {self.pat_yardline},
-            "1PC_yardline" = {self.one_PC_Yardline},
-            "2PC_yardline" = {self.two_PC_Yardline},
-            "3PC_yardline" = {self.three_PC_Yardline},
-            "quarters" = {self.quarters},
-            "timeouts_per_half" = {self.timeouts_per_half},
-            "ot_period_seconds" = {self.ot_period_seconds},
-            "game_seconds" = {self.game_seconds},
-            "half_seconds" = {self.half_seconds},
-            "quarter_seconds" = {self.quarter_seconds},
-            "ot_periods" = {self.ot_periods},
-            "ot_periods_until_shootout" = {self.ot_periods_until_shootout},
-            "min_xfl_ot_periods" = {self.min_xfl_ot_periods},
-            "set_xfl_ot_periods" = {self.set_xfl_ot_periods},
-            "touchdown_points" = {self.touchdown_points},
-            "field_goal_points" = {self.field_goal_points},
-            "safety_points" = {self.safety_points},
-            "pat_points" = {self.pat_points},
-            "pat_defense" = {self.pat_defense},
-            "pat_safety" = {self.pat_safety},
-            "players_on_field" = {self.players_on_field},
-            "xfl_pat" = {self.xfl_pat_enabled},
+            "downs" = ?,
+            "first_down_yards" = ?,
+            "kickoff_yardline" = ?,
+            "safety_kick_yardline" = ?,
+            "kickoff_touchback_yardline" = ?,
+            "punt_touchback_yardline" = ?,
+            "normal_touchback_yardline" = ?,
+            "kansas_ot_yardline" = ?,
+            "pat_yardline" = ?,
+            "1PC_yardline" = ?,
+            "2PC_yardline" = ?,
+            "3PC_yardline" = ?,
+            "quarters" = ?,
+            "timeouts_per_half" = ?,
+            "ot_period_seconds" = ?,
+            "game_seconds" = ?,
+            "half_seconds" = ?,
+            "quarter_seconds" = ?,
+            "ot_periods" = ?,
+            "ot_periods_until_shootout" = ?,
+            "min_xfl_ot_periods" = ?,
+            "set_xfl_ot_periods" = ?,
+            "touchdown_points" = ?,
+            "field_goal_points" = ?,
+            "safety_points" = ?,
+            "pat_points" = ?,
+            "pat_defense" = ?,
+            "pat_safety" = ?,
+            "players_on_field" = ?,
+            "xfl_pat" = ?,
 
-            "preseason_ot_enabled" = {self.preseason_ot_enabled},
-            "reg_season_ot_enabled" = {self.reg_season_ot_enabled},
-            "postseason_ot_enabled" = {self.postseason_ot_enabled},
+            "preseason_ot_enabled" = ?,
+            "reg_season_ot_enabled" = ?,
+            "postseason_ot_enabled" = ?,
 
-            "preseason_ot_type" = "{self.preseason_ot_type}",
-            "reg_season_ot_type" = "{self.reg_season_ot_type}",
-            "postseason_ot_type" = "{self.postseason_ot_type}",
+            "preseason_ot_type" = ?,
+            "reg_season_ot_type" = ?,
+            "postseason_ot_type" = ?,
 
-            "two_forward_passes" = {self.two_forward_passes},
-            "spikes_are_team_stats" = {self.spikes_are_team_stats},
-            "sacks_are_rushes" = {self.sacks_are_rushes},
-            "kneeldowns_are_team_stats" = {self.kneeldowns_are_team_stats},
-            "kickoff_fc_always_goes_to_touchback" = {kickoff_fc},
-            "kickoffs_enabled" = {self.kickoffs_enabled},
-            "use_xfl_kickoff" = {self.use_xfl_kickoff},
-            "drop_kick_enabled" = {self.drop_kick_enabled},
-            "drop_kick_bonus_point" = {self.drop_kick_bonus_point},
-            "fg_adds_ez_length" = {self.fg_adds_ez_length},
-            "long_fg_bonus_point" = {self.long_fg_bonus_point},
-            "xp_is_a_fg" = {self.xp_is_a_fg},
-            "rouges_enabled" = {self.rouges_enabled},
-            "punting_enabled" = {self.punting_enabled},
-            "onside_punts_enabled" = {self.onside_punts_enabled},
-            "special_onside_play_enabled" = {self.special_onside_play_enabled},
-            "fair_catch_enabled" = {self.fair_catch_enabled}
+            "two_forward_passes" = ?,
+            "spikes_are_team_stats" = ?,
+            "sacks_are_rushes" = ?,
+            "kneeldowns_are_team_stats" = ?,
+            "kickoff_fc_always_goes_to_touchback" = ?,
+            "kickoffs_enabled" = ?,
+            "use_xfl_kickoff" = ?,
+            "drop_kick_enabled" = ?,
+            "drop_kick_bonus_point" = ?,
+            "fg_adds_ez_length" = ?,
+            "long_fg_bonus_point" = ?,
+            "xp_is_a_fg" = ?,
+            "rouges_enabled" = ?,
+            "punting_enabled" = ?,
+            "onside_punts_enabled" = ?,
+            "special_onside_play_enabled" = ?,
+            "fair_catch_enabled" = ?
 
         WHERE
-            "league_id" = "{self.league_id}"
+            "league_id" = ?
         """
         # print(sql_script)
 
-        self.sqlite3_cur.executescript(sql_script)
+        self.sqlite3_cur.executemany(
+            sql_script,
+            [(
+                self.league_id,
+                self.league_long_name,
+                self.league_short_name,
+                self.league_notes,
+                self.field_length,
+                self.downs,
+                self.first_down_yards,
+                self.kickoff_yardline,
+                self.safety_kick_yardline,
+                self.kickoff_touchback_yardline,
+                self.punt_touchback_yardline,
+                self.normal_touchback_yardline,
+                self.kansas_ot_yardline,
+                self.pat_yardline,
+                self.one_PC_Yardline,
+                self.two_PC_Yardline,
+                self.three_PC_Yardline,
+                self.quarters,
+                self.timeouts_per_half,
+                self.ot_period_seconds,
+                self.game_seconds,
+                self.half_seconds,
+                self.quarter_seconds,
+                self.ot_periods,
+                self.ot_periods_until_shootout,
+                self.min_xfl_ot_periods,
+                self.set_xfl_ot_periods,
+                self.touchdown_points,
+                self.field_goal_points,
+                self.safety_points,
+                self.pat_points,
+                self.pat_defense,
+                self.pat_safety,
+                self.players_on_field,
+                self.xfl_pat_enabled,
+                self.preseason_ot_enabled,
+                self.reg_season_ot_enabled,
+                self.postseason_ot_enabled,
+                self.preseason_ot_type,
+                self.reg_season_ot_type,
+                self.postseason_ot_type,
+                self.two_forward_passes,
+                self.spikes_are_team_stats,
+                self.sacks_are_rushes,
+                self.kneeldowns_are_team_stats,
+                kickoff_fc,
+                self.kickoffs_enabled,
+                self.use_xfl_kickoff,
+                self.drop_kick_enabled,
+                self.drop_kick_bonus_point,
+                self.fg_adds_ez_length,
+                self.long_fg_bonus_point,
+                self.xp_is_a_fg,
+                self.rouges_enabled,
+                self.punting_enabled,
+                self.onside_punts_enabled,
+                self.special_onside_play_enabled,
+                self.fair_catch_enabled,
+                self.league_id
+
+            )]
+        )
         self.sqlite3_con.commit()
 
     def initial_data_load(self):
@@ -911,7 +979,7 @@ class LeagueView:
         ]
 
         window = sg.Window(
-            "About",
+            "Edit League...",
             layout=layout,
             # size=(500, 600),
             resizable=False,
@@ -1008,7 +1076,7 @@ class LeagueView:
                         )
                     del check
                 elif check_flag == "No":
-                    keep_open = False
+                    pass
                 del check_flag
                 window["-APPLY_BUTTON-"].update(
                     disabled=True
@@ -1058,6 +1126,33 @@ class LeagueView:
                 )
                 self.league_id = values["-LG_SHORT_NAME-"].upper()
                 change_count += 1
+
+            if event == "-LG_LONG_NAME-" and (
+                len(values["-LG_LONG_NAME-"]) > 256
+            ):
+                window["-LG_LONG_NAME-"].update(
+                    values["-LG_LONG_NAME-"][:-1]
+                )
+            elif event == "-LG_LONG_NAME-" and (
+                values["-LG_LONG_NAME-"] and
+                values["-LG_LONG_NAME-"][-1] not in (
+                    self.letters_and_numbers
+                )
+            ):
+                window["-LG_LONG_NAME-"].update(
+                    values["-LG_LONG_NAME-"][:-1]
+                )
+                self.league_long_name = values["-LG_LONG_NAME-"]
+            elif event == "-LG_LONG_NAME-" and (
+                values["-LG_LONG_NAME-"] and
+                values["-LG_LONG_NAME-"][-1] in (
+                    self.letters_and_numbers
+                )
+            ):
+                window["-LG_LONG_NAME-"].update(
+                    values["-LG_LONG_NAME-"]
+                )
+                self.league_long_name = values["-LG_LONG_NAME-"]
 
             if event == "-LG_LONG_NAME-":
                 self.league_long_name = values["-LG_LONG_NAME-"]
@@ -1246,15 +1341,16 @@ def safety_check_league_ids(
     Validates that if you're changing the league ID,
     you're not infringing on a league ID that already exists.
     """
-    sql_script = f"""
+    sql_script = """
     SELECT DISTINCT
         league_id
     FROM fb_leagues
-    WHERE league_id != "{league_id_original}"
+    WHERE league_id != ?
     """
-    lg_id_df = pl.read_database(
-        query=sql_script,
-        connection=cur,
+    data = cur.execute(sql_script, [(league_id_original)])
+    data.fetchall()
+    lg_id_df = pl.DataFrame(
+        data=data,
         schema_overrides={"league_id": pl.String},
     )
     if len(lg_id_df) > 0:
@@ -1279,8 +1375,9 @@ def new_league_view(settings_json: dict):
     sg.theme(settings_json["app_theme"])
     league_id = ""
     league_long_name = ""
-    letters_and_numbers = "abcdefghijklmnopqrstuvwxyz" +\
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    letters_and_numbers = LettersAndNumbers.letters_and_numbers(
+        include_space=True
+    )
 
     base_ruleset_arr = [
         "AAF",
@@ -1310,6 +1407,7 @@ def new_league_view(settings_json: dict):
     ]
     current_year = datetime.now().year
     latest_season = current_year
+
     layout = [
         [
             sg.Text(
@@ -1380,13 +1478,14 @@ def new_league_view(settings_json: dict):
     ]
 
     window = sg.Window(
-        "About",
+        "New League...",
         layout=layout,
         # size=(500, 600),
         resizable=False,
         finalize=True,
         keep_on_top=False
     )
+
     keep_open = True
     while keep_open is True:
         event, values = window.read(timeout=1000)
@@ -1402,7 +1501,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "NFL"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -1429,9 +1528,9 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
+                ?,
+                ?,
+                ?,
                 100,
                 4,
                 10,
@@ -1451,7 +1550,8 @@ def new_league_view(settings_json: dict):
                 "Super Modified Sudden Death OT",
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -1477,8 +1577,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 100,
                 4,
                 10,
@@ -1498,9 +1598,25 @@ def new_league_view(settings_json: dict):
                 "Super Modified Sudden Death OT",
                 1
             );
-            """
+            """.replace("            ", "")
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name
+                    )]
+                )
+                sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
                 sqlite3_con.commit()
                 keep_open = False
             except sqlite3.IntegrityError:
@@ -1517,7 +1633,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "NCAA"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -1548,9 +1664,9 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
+                ?,
+                ?,
+                ?,
                 100,
                 4,
                 10,
@@ -1574,7 +1690,8 @@ def new_league_view(settings_json: dict):
                 1,
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -1604,8 +1721,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 100,
                 4,
                 10,
@@ -1632,7 +1749,23 @@ def new_league_view(settings_json: dict):
 
             """
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name,
+                    )]
+                )
+                sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
                 sqlite3_con.commit()
                 keep_open = False
             except sqlite3.IntegrityError:
@@ -1649,7 +1782,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "CFL"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -1679,9 +1812,9 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
+                ?,
+                ?,
+                ?,
                 110,
                 3,
                 10,
@@ -1704,7 +1837,8 @@ def new_league_view(settings_json: dict):
                 0,
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -1733,8 +1867,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 110,
                 3,
                 10,
@@ -1759,7 +1893,23 @@ def new_league_view(settings_json: dict):
             );
             """
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name,
+                    )]
+                )
+                sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
                 sqlite3_con.commit()
                 keep_open = False
             except sqlite3.IntegrityError:
@@ -1776,7 +1926,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "UFL (2024)"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -1803,9 +1953,9 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
+                ?,
+                ?,
+                ?,
                 20,
                 20,
                 75,
@@ -1825,7 +1975,8 @@ def new_league_view(settings_json: dict):
                 1,
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -1851,8 +2002,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 20,
                 20,
                 75,
@@ -1874,7 +2025,23 @@ def new_league_view(settings_json: dict):
             );
             """
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name,
+                    )]
+                )
+                sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
                 sqlite3_con.commit()
                 keep_open = False
             except sqlite3.IntegrityError:
@@ -1891,7 +2058,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "XFL"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -1915,9 +2082,9 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
+                ?,
+                ?,
+                ?,
                 30,
                 65,
                 65,
@@ -1934,7 +2101,8 @@ def new_league_view(settings_json: dict):
                 1,
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -1957,8 +2125,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 30,
                 65,
                 65,
@@ -1978,7 +2146,23 @@ def new_league_view(settings_json: dict):
 
             """
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name,
+                    )]
+                )
+                sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
                 sqlite3_con.commit()
                 keep_open = False
             except sqlite3.IntegrityError:
@@ -1995,7 +2179,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "AAF"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -2009,16 +2193,17 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
+                ?,
+                ?,
+                ?,
                 10,
                 0,
                 0,
                 0,
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -2031,8 +2216,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 10,
                 0,
                 0,
@@ -2042,7 +2227,23 @@ def new_league_view(settings_json: dict):
 
             """
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name
+                    )]
+                )
+                sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
                 sqlite3_con.commit()
                 keep_open = False
             except sqlite3.IntegrityError:
@@ -2059,7 +2260,7 @@ def new_league_view(settings_json: dict):
         elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
             values["-BASE_RULESET-"] == "High School"
         ):
-            sql_script = f"""
+            sql_script = """
             INSERT INTO "fb_leagues"
             (
                 "league_id",
@@ -2073,10 +2274,10 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                -- Not all HS leagues are built the same,
+                ?,
+                ?,
+                ?,
+                -- Not all HS leagues are built the same
                 -- and I am not building out a ruleset for literally
                 -- every HS league.
                 2880,
@@ -2085,7 +2286,8 @@ def new_league_view(settings_json: dict):
                 1,
                 1
             );
-
+            """
+            sql_script_2 = """
             INSERT INTO "fb_seasons"
             (
                 "season",
@@ -2098,8 +2300,8 @@ def new_league_view(settings_json: dict):
             )
             VALUES
             (
-                {latest_season},
-                "{league_id}",
+                ?,
+                ?,
                 2880,
                 1440,
                 720,
@@ -2108,8 +2310,25 @@ def new_league_view(settings_json: dict):
             );
             """
             try:
-                sqlite3_cur.executescript(sql_script)
+                sqlite3_cur.executemany(
+                    sql_script,
+                    [(
+                        league_id,
+                        league_id,
+                        league_long_name
+                    )]
+                )
                 sqlite3_con.commit()
+
+                sqlite3_cur.executemany(
+                    sql_script_2,
+                    [(
+                        latest_season,
+                        league_id
+                    )]
+                )
+                sqlite3_con.commit()
+
                 keep_open = False
             except sqlite3.IntegrityError:
                 sg.popup_error(
@@ -2123,9 +2342,9 @@ def new_league_view(settings_json: dict):
                 )
                 raise e
 
-        if event == "-LG_SHORT_NAME-" and len(
-            values["-LG_SHORT_NAME-"]
-        ) > 5:
+        if event == "-LG_SHORT_NAME-" and (
+            len(values["-LG_SHORT_NAME-"]) > 5
+        ):
             window["-LG_SHORT_NAME-"].update(
                 values["-LG_SHORT_NAME-"][:-1]
             )
@@ -2149,9 +2368,9 @@ def new_league_view(settings_json: dict):
                 values["-LG_SHORT_NAME-"].upper()
             )
             league_id = values["-LG_SHORT_NAME-"].upper()
-        if event == "-LG_LONG_NAME-" and len(
-            values["-LG_LONG_NAME-"]
-        ) > 256:
+        if event == "-LG_LONG_NAME-" and (
+            len(values["-LG_LONG_NAME-"]) > 256
+        ):
             window["-LG_LONG_NAME-"].update(
                 values["-LG_LONG_NAME-"][:-1]
             )

--- a/core/views/edit_season_view.py
+++ b/core/views/edit_season_view.py
@@ -1,35 +1,36 @@
 """
-- Creation Date: 05/12/2024 05:15 PM EDT
-- Last Updated: 05/12/2024 05:25 PM EDT
+- Creation Date: 03/10/2024 04:35 PM EDT
+- Last Updated: 05/18/2024 02:05 AM EDT
 - Authors: Joseph Armstrong (armstrongjoseph08@gmail.com)
 - file: `./core/views/edit_season_view.py`
 - Purpose: Code behind for the window
-    that allows a user to view and edit a season for a league.
+    that allows a user to view and edit leagues.
 """
 
-from datetime import datetime
 import logging
 import operator
 import sqlite3
+from datetime import datetime
+
 import polars as pl
 import PySimpleGUI as sg
 
 from core.database.load_db_elements import SqliteLoadData
 from core.database.sqlite3_connectors import initialize_sqlite3_connectors
-from core.other.embedded import EmbeddedElements
+from core.other.embedded import EmbeddedElements, LettersAndNumbers
 
 
-class LeagueView:
+class SeasonView:
     """
-    Class for handling logic with editing league settings.
+    Class for handling logic with editing the rules for a season in a league.
     """
-    letters_all = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    letters_lower = "abcdefghijklmnopqrstuvwxyz"
-    letters_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    numbers_all = "0123456789"
-    letters_and_numbers = "abcdefghijklmnopqrstuvwxyz" +\
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    upper_letters_and_numbers = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+    letters_all = LettersAndNumbers.letters_all(include_space=True)
+    letters_lower = LettersAndNumbers.letters_lower()
+    letters_upper = LettersAndNumbers.letters_upper()
+    numbers_all = LettersAndNumbers.numbers_all()
+    letters_and_numbers = LettersAndNumbers.letters_and_numbers()
+    upper_letters_and_numbers = LettersAndNumbers.upper_letters_and_numbers()
     # sqlite3 connectors
     sqlite3_con = None
     sqlite3_cur = None
@@ -44,15 +45,16 @@ class LeagueView:
         "XFL OT",
         "Full Period OT",
     ]
-    lg_df = pl.DataFrame()
+    season_df = pl.DataFrame()
 
+    season = 0
     # League variables
     league_id_original = ""
     league_id = ""
-    league_long_name = ""
-    league_short_name = ""
+    # league_long_name = ""
+    # league_short_name = ""
     # league_default_sex = ""
-    league_notes = ""
+    season_notes = ""
     changed_settings = False
 
     field_length = 0
@@ -115,11 +117,8 @@ class LeagueView:
     fair_catch_enabled = False
     special_onside_play_enabled = False
 
-    def __init__(
-        self,
-        settings_json: dict,
-        league_id: str
-    ):
+    def __init__(self, settings_json: dict, league_id: str, season: int):
+        self.season = season
         self.league_id = league_id
         self.league_id_original = league_id
 
@@ -129,7 +128,7 @@ class LeagueView:
         self.settings_dict = settings_json
         self.app_theme = self.settings_dict["app_theme"]
         self.initial_data_load()
-        self.league_edit_view()
+        self.season_edit_view()
 
     def changed_settings_check(self) -> str:
         check = sg.popup_yes_no(
@@ -137,217 +136,278 @@ class LeagueView:
             You have unsaved changes.
             Do you want to save your changes?
             """.replace(
-                "            ",
-                ""
+                "            ", ""
             ),
-            title="Unsaved Settings"
+            title="Unsaved Settings",
         )
         return check
 
-    def update_league_settings(self):
-        """
-        """
+    def update_season_settings(self):
+        """ """
         # Done to avoid a formatting error being raised
         # by a line being more than 80 characters long.
         kickoff_fc = self.kickoff_fc_always_goes_to_touchback
 
-        sql_script = f"""
-        UPDATE fb_leagues
+        sql_script = """
+        UPDATE fb_seasons
         SET
-            "league_id" = "{self.league_id}",
-            "league_long_name" = "{self.league_long_name}",
-            "league_short_name" = "{self.league_short_name}",
-            "league_notes" = "{self.league_notes}",
-            "field_length" = {self.field_length},
+            "season" = ?,
+            "league_id" = ?,
+            "season_notes" = ?,
+            "field_length" = ?,
 
-            "downs" = {self.downs},
-            "first_down_yards" = {self.first_down_yards},
-            "kickoff_yardline" = {self.kickoff_yardline},
-            "safety_kick_yardline" = {self.safety_kick_yardline},
-            "kickoff_touchback_yardline" = {self.kickoff_touchback_yardline},
-            "punt_touchback_yardline" = {self.punt_touchback_yardline},
-            "normal_touchback_yardline" = {self.normal_touchback_yardline},
-            "kansas_ot_yardline" = {self.kansas_ot_yardline},
-            "pat_yardline" = {self.pat_yardline},
-            "1PC_yardline" = {self.one_PC_Yardline},
-            "2PC_yardline" = {self.two_PC_Yardline},
-            "3PC_yardline" = {self.three_PC_Yardline},
-            "quarters" = {self.quarters},
-            "timeouts_per_half" = {self.timeouts_per_half},
-            "ot_period_seconds" = {self.ot_period_seconds},
-            "game_seconds" = {self.game_seconds},
-            "half_seconds" = {self.half_seconds},
-            "quarter_seconds" = {self.quarter_seconds},
-            "ot_periods" = {self.ot_periods},
-            "ot_periods_until_shootout" = {self.ot_periods_until_shootout},
-            "min_xfl_ot_periods" = {self.min_xfl_ot_periods},
-            "set_xfl_ot_periods" = {self.set_xfl_ot_periods},
-            "touchdown_points" = {self.touchdown_points},
-            "field_goal_points" = {self.field_goal_points},
-            "safety_points" = {self.safety_points},
-            "pat_points" = {self.pat_points},
-            "pat_defense" = {self.pat_defense},
-            "pat_safety" = {self.pat_safety},
-            "players_on_field" = {self.players_on_field},
-            "xfl_pat" = {self.xfl_pat_enabled},
+            "downs" = ?,
+            "first_down_yards" = ?,
+            "kickoff_yardline" = ?,
+            "safety_kick_yardline" = ?,
+            "kickoff_touchback_yardline" = ?,
+            "punt_touchback_yardline" = ?,
+            "normal_touchback_yardline" = ?,
+            "kansas_ot_yardline" = ?,
+            "pat_yardline" = ?,
+            "1PC_yardline" = ?,
+            "2PC_yardline" = ?,
+            "3PC_yardline" = ?,
+            "quarters" = ?,
+            "timeouts_per_half" = ?,
+            "ot_period_seconds" = ?,
+            "game_seconds" = ?,
+            "half_seconds" = ?,
+            "quarter_seconds" = ?,
+            "ot_periods" = ?,
+            "ot_periods_until_shootout" = ?,
+            "min_xfl_ot_periods" = ?,
+            "set_xfl_ot_periods" = ?,
+            "touchdown_points" = ?,
+            "field_goal_points" = ?,
+            "safety_points" = ?,
+            "pat_points" = ?,
+            "pat_defense" = ?,
+            "pat_safety" = ?,
+            "players_on_field" = ?,
+            "xfl_pat" = ?,
 
-            "preseason_ot_enabled" = {self.preseason_ot_enabled},
-            "reg_season_ot_enabled" = {self.reg_season_ot_enabled},
-            "postseason_ot_enabled" = {self.postseason_ot_enabled},
+            "preseason_ot_enabled" = ?,
+            "reg_season_ot_enabled" = ?,
+            "postseason_ot_enabled" = ?,
 
-            "preseason_ot_type" = "{self.preseason_ot_type}",
-            "reg_season_ot_type" = "{self.reg_season_ot_type}",
-            "postseason_ot_type" = "{self.postseason_ot_type}",
+            "preseason_ot_type" = ?,
+            "reg_season_ot_type" = ?,
+            "postseason_ot_type" = ?,
 
-            "two_forward_passes" = {self.two_forward_passes},
-            "spikes_are_team_stats" = {self.spikes_are_team_stats},
-            "sacks_are_rushes" = {self.sacks_are_rushes},
-            "kneeldowns_are_team_stats" = {self.kneeldowns_are_team_stats},
-            "kickoff_fc_always_goes_to_touchback" = {kickoff_fc},
-            "kickoffs_enabled" = {self.kickoffs_enabled},
-            "use_xfl_kickoff" = {self.use_xfl_kickoff},
-            "drop_kick_enabled" = {self.drop_kick_enabled},
-            "drop_kick_bonus_point" = {self.drop_kick_bonus_point},
-            "fg_adds_ez_length" = {self.fg_adds_ez_length},
-            "long_fg_bonus_point" = {self.long_fg_bonus_point},
-            "xp_is_a_fg" = {self.xp_is_a_fg},
-            "rouges_enabled" = {self.rouges_enabled},
-            "punting_enabled" = {self.punting_enabled},
-            "onside_punts_enabled" = {self.onside_punts_enabled},
-            "special_onside_play_enabled" = {self.special_onside_play_enabled},
-            "fair_catch_enabled" = {self.fair_catch_enabled}
+            "two_forward_passes" = ?,
+            "spikes_are_team_stats" = ?,
+            "sacks_are_rushes" = ?,
+            "kneeldowns_are_team_stats" = ?,
+            "kickoff_fc_always_goes_to_touchback" = ?,
+            "kickoffs_enabled" = ?,
+            "use_xfl_kickoff" = ?,
+            "drop_kick_enabled" = ?,
+            "drop_kick_bonus_point" = ?,
+            "fg_adds_ez_length" = ?,
+            "long_fg_bonus_point" = ?,
+            "xp_is_a_fg" = ?,
+            "rouges_enabled" = ?,
+            "punting_enabled" = ?,
+            "onside_punts_enabled" = ?,
+            "special_onside_play_enabled" = ?,
+            "fair_catch_enabled" = ?
 
         WHERE
-            "league_id" = "{self.league_id}"
+            "league_id" = ? AND
+            "season" = ?
         """
         # print(sql_script)
 
-        self.sqlite3_cur.executescript(sql_script)
+        self.sqlite3_cur.executemany(
+            sql_script,
+            [(
+                self.season,
+                self.league_id,
+                self.season_notes,
+                self.field_length,
+
+                self.downs,
+                self.first_down_yards,
+                self.kickoff_yardline,
+                self.safety_kick_yardline,
+                self.kickoff_touchback_yardline,
+                self.punt_touchback_yardline,
+                self.normal_touchback_yardline,
+                self.kansas_ot_yardline,
+                self.pat_yardline,
+                self.one_PC_Yardline,
+                self.two_PC_Yardline,
+                self.three_PC_Yardline,
+                self.quarters,
+                self.timeouts_per_half,
+                self.ot_period_seconds,
+                self.game_seconds,
+                self.half_seconds,
+                self.quarter_seconds,
+                self.ot_periods,
+                self.ot_periods_until_shootout,
+                self.min_xfl_ot_periods,
+                self.set_xfl_ot_periods,
+                self.touchdown_points,
+                self.field_goal_points,
+                self.safety_points,
+                self.pat_points,
+                self.pat_defense,
+                self.pat_safety,
+                self.players_on_field,
+                self.xfl_pat_enabled,
+                self.preseason_ot_enabled,
+                self.reg_season_ot_enabled,
+                self.postseason_ot_enabled,
+                self.preseason_ot_type,
+                self.reg_season_ot_type,
+                self.postseason_ot_type,
+                self.two_forward_passes,
+                self.spikes_are_team_stats,
+                self.sacks_are_rushes,
+                self.kneeldowns_are_team_stats,
+                kickoff_fc,
+                self.kickoffs_enabled,
+                self.use_xfl_kickoff,
+                self.drop_kick_enabled,
+                self.drop_kick_bonus_point,
+                self.fg_adds_ez_length,
+                self.long_fg_bonus_point,
+                self.xp_is_a_fg,
+                self.rouges_enabled,
+                self.punting_enabled,
+                self.onside_punts_enabled,
+                self.special_onside_play_enabled,
+                self.fair_catch_enabled,
+                self.league_id,
+                self.season
+
+            )]
+        )
         self.sqlite3_con.commit()
+        del kickoff_fc
 
     def initial_data_load(self):
-        """
-
-        """
-        self.lg_df = SqliteLoadData.load_leagues(
+        """ """
+        self.season_df = SqliteLoadData.load_seasons(
             con=self.sqlite3_con, cur=self.sqlite3_cur
         )
-        # print(self.lg_df)
-        self.lg_df = self.lg_df.filter(pl.col("league_id") == self.league_id)
+        # print(self.season_df)
+        self.season_df = self.season_df.filter(
+            (pl.col("league_id") == self.league_id) &
+            (pl.col("season") == self.season)
+        )
 
         # The following line is not run because we already know
         # what the `league_id` is.
-        # self.league_id = self.lg_df["league_id"][0]
-        self.league_long_name = self.lg_df["league_long_name"][0]
-        self.league_short_name = self.lg_df["league_short_name"][0]
-        # self.league_default_sex = self.lg_df["league_default_sex"][0]
-        self.league_notes = self.lg_df["league_notes"][0]
+        # self.league_id = self.season_df["league_id"][0]
+        # self.league_long_name = self.season_df["league_long_name"][0]
+        # self.league_short_name = self.season_df["league_short_name"][0]
+        # self.league_default_sex = self.season_df["league_default_sex"][0]
+        self.season_notes = self.season_df["season_notes"][0]
 
-        self.field_length = self.lg_df["field_length"][0]
-        self.downs = self.lg_df["downs"][0]
-        self.first_down_yards = self.lg_df["first_down_yards"][0]
-        self.end_zone_length = self.lg_df["end_zone_length"][0]
-        self.kickoff_yardline = self.lg_df["kickoff_yardline"][0]
-        self.safety_kick_yardline = self.lg_df["safety_kick_yardline"][0]
-        self.kickoff_touchback_yardline = self.lg_df[
-            "kickoff_touchback_yardline"
-        ][0]
-        self.punt_touchback_yardline = self.lg_df["punt_touchback_yardline"][0]
-        self.normal_touchback_yardline = self.lg_df[
-            "normal_touchback_yardline"
-        ][0]
-        self.kansas_ot_yardline = self.lg_df["kansas_ot_yardline"][0]
-        self.pat_yardline = self.lg_df["pat_yardline"][0]
-        self.one_PC_Yardline = self.lg_df["1PC_yardline"][0]
-        self.two_PC_Yardline = self.lg_df["2PC_yardline"][0]
-        self.three_PC_Yardline = self.lg_df["3PC_yardline"][0]
-        self.quarters = self.lg_df["quarters"][0]
-        self.timeouts_per_half = self.lg_df["timeouts_per_half"][0]
-        self.ot_period_seconds = self.lg_df["ot_period_seconds"][0]
-        self.game_seconds = self.lg_df["game_seconds"][0]
-        self.half_seconds = self.lg_df["half_seconds"][0]
-        self.quarter_seconds = self.lg_df["quarter_seconds"][0]
-        self.ot_periods = self.lg_df["ot_periods"][0]
-        self.ot_periods_until_shootout = self.lg_df[
-            "ot_periods_until_shootout"
-        ][0]
-        self.min_xfl_ot_periods = self.lg_df["min_xfl_ot_periods"][0]
-        self.set_xfl_ot_periods = self.lg_df["set_xfl_ot_periods"][0]
-        self.touchdown_points = self.lg_df["touchdown_points"][0]
-        self.field_goal_points = self.lg_df["field_goal_points"][0]
-        self.safety_points = self.lg_df["safety_points"][0]
-        self.pat_points = self.lg_df["pat_points"][0]
-        self.pat_defense = self.lg_df["pat_defense"][0]
-        self.pat_safety = self.lg_df["pat_safety"][0]
-        self.players_on_field = self.lg_df["players_on_field"][0]
+        self.field_length = self.season_df["field_length"][0]
+        self.downs = self.season_df["downs"][0]
+        self.first_down_yards = self.season_df["first_down_yards"][0]
+        self.end_zone_length = self.season_df["end_zone_length"][0]
+        self.kickoff_yardline = self.season_df["kickoff_yardline"][0]
+        self.safety_kick_yardline = self.season_df["safety_kick_yardline"][0]
+        self.kickoff_touchback_yardline = self.season_df[
+            "kickoff_touchback_yardline"][0]
+        self.punt_touchback_yardline = self.season_df[
+            "punt_touchback_yardline"][0]
+        self.normal_touchback_yardline = self.season_df[
+            "normal_touchback_yardline"][0]
+        self.kansas_ot_yardline = self.season_df["kansas_ot_yardline"][0]
+        self.pat_yardline = self.season_df["pat_yardline"][0]
+        self.one_PC_Yardline = self.season_df["1PC_yardline"][0]
+        self.two_PC_Yardline = self.season_df["2PC_yardline"][0]
+        self.three_PC_Yardline = self.season_df["3PC_yardline"][0]
+        self.quarters = self.season_df["quarters"][0]
+        self.timeouts_per_half = self.season_df["timeouts_per_half"][0]
+        self.ot_period_seconds = self.season_df["ot_period_seconds"][0]
+        self.game_seconds = self.season_df["game_seconds"][0]
+        self.half_seconds = self.season_df["half_seconds"][0]
+        self.quarter_seconds = self.season_df["quarter_seconds"][0]
+        self.ot_periods = self.season_df["ot_periods"][0]
+        self.ot_periods_until_shootout = self.season_df[
+            "ot_periods_until_shootout"][0]
+        self.min_xfl_ot_periods = self.season_df["min_xfl_ot_periods"][0]
+        self.set_xfl_ot_periods = self.season_df["set_xfl_ot_periods"][0]
+        self.touchdown_points = self.season_df["touchdown_points"][0]
+        self.field_goal_points = self.season_df["field_goal_points"][0]
+        self.safety_points = self.season_df["safety_points"][0]
+        self.pat_points = self.season_df["pat_points"][0]
+        self.pat_defense = self.season_df["pat_defense"][0]
+        self.pat_safety = self.season_df["pat_safety"][0]
+        self.players_on_field = self.season_df["players_on_field"][0]
 
-        self.preseason_ot_enabled = self.lg_df["preseason_ot_enabled"][0]
-        self.reg_season_ot_enabled = self.lg_df["reg_season_ot_enabled"][0]
-        self.postseason_ot_enabled = self.lg_df["postseason_ot_enabled"][0]
+        self.preseason_ot_enabled = self.season_df["preseason_ot_enabled"][0]
+        self.reg_season_ot_enabled = self.season_df["reg_season_ot_enabled"][0]
+        self.postseason_ot_enabled = self.season_df["postseason_ot_enabled"][0]
 
-        self.xfl_pat_enabled = self.lg_df["xfl_pat"][0]
+        self.xfl_pat_enabled = self.season_df["xfl_pat"][0]
 
-        self.preseason_ot_type = self.lg_df["preseason_ot_type"][0]
-        self.reg_season_ot_type = self.lg_df["reg_season_ot_type"][0]
-        self.postseason_ot_type = self.lg_df["postseason_ot_type"][0]
+        self.preseason_ot_type = self.season_df["preseason_ot_type"][0]
+        self.reg_season_ot_type = self.season_df["reg_season_ot_type"][0]
+        self.postseason_ot_type = self.season_df["postseason_ot_type"][0]
 
-        self.two_forward_passes = self.lg_df["two_forward_passes"][0]
-        self.spikes_are_team_stats = self.lg_df["spikes_are_team_stats"][0]
-        self.sacks_are_rushes = self.lg_df["sacks_are_rushes"][0]
-        self.kneeldowns_are_team_stats = self.lg_df[
-            "kneeldowns_are_team_stats"
-        ][0]
-        self.kickoff_fc_always_goes_to_touchback = self.lg_df[
-            "kickoff_fc_always_goes_to_touchback"
-        ][0]
-        self.kickoffs_enabled = self.lg_df["kickoffs_enabled"][0]
-        self.use_xfl_kickoff = self.lg_df["use_xfl_kickoff"][0]
-        self.drop_kick_enabled = self.lg_df["drop_kick_enabled"][0]
-        self.drop_kick_bonus_point = self.lg_df["drop_kick_bonus_point"][0]
-        self.fg_adds_ez_length = self.lg_df["fg_adds_ez_length"][0]
-        self.long_fg_bonus_point = self.lg_df["long_fg_bonus_point"][0]
-        self.xp_is_a_fg = self.lg_df["xp_is_a_fg"][0]
-        self.rouges_enabled = self.lg_df["rouges_enabled"][0]
-        self.punting_enabled = self.lg_df["punting_enabled"][0]
-        self.onside_punts_enabled = self.lg_df["onside_punts_enabled"][0]
-        self.fair_catch_enabled = self.lg_df["fair_catch_enabled"][0]
-        self.special_onside_play_enabled = self.lg_df[
+        self.two_forward_passes = self.season_df["two_forward_passes"][0]
+        self.spikes_are_team_stats = self.season_df["spikes_are_team_stats"][0]
+        self.sacks_are_rushes = self.season_df["sacks_are_rushes"][0]
+        self.kneeldowns_are_team_stats = self.season_df[
+            "kneeldowns_are_team_stats"][0]
+        self.kickoff_fc_always_goes_to_touchback = self.season_df[
+            "kickoff_fc_always_goes_to_touchback"][0]
+        self.kickoffs_enabled = self.season_df["kickoffs_enabled"][0]
+        self.use_xfl_kickoff = self.season_df["use_xfl_kickoff"][0]
+        self.drop_kick_enabled = self.season_df["drop_kick_enabled"][0]
+        self.drop_kick_bonus_point = self.season_df["drop_kick_bonus_point"][0]
+        self.fg_adds_ez_length = self.season_df["fg_adds_ez_length"][0]
+        self.long_fg_bonus_point = self.season_df["long_fg_bonus_point"][0]
+        self.xp_is_a_fg = self.season_df["xp_is_a_fg"][0]
+        self.rouges_enabled = self.season_df["rouges_enabled"][0]
+        self.punting_enabled = self.season_df["punting_enabled"][0]
+        self.onside_punts_enabled = self.season_df["onside_punts_enabled"][0]
+        self.fair_catch_enabled = self.season_df["fair_catch_enabled"][0]
+        self.special_onside_play_enabled = self.season_df[
             "special_onside_play_enabled"
         ][0]
 
-    def league_edit_view(self):
+    def season_edit_view(self):
         sg.theme(self.app_theme)
         lg_basics = [
-            [
-                sg.Text(
-                    "League Full Name:\t\t"
-                ),
-                sg.Input(
-                    default_text=self.league_long_name,
-                    key="-LG_LONG_NAME-",
-                    enable_events=True,
-                    size=(40, 1)
-                ),
-                sg.Push(),
-            ],
-            [
-                sg.Text("League Abbreviation:\t"),
-                sg.Input(
-                    default_text=self.league_short_name,
-                    key="-LG_SHORT_NAME-",
-                    enable_events=True,
-                    size=(7, 1)
-                ),
-                sg.Push(),
-            ],
+            # [
+            #     sg.Text(
+            #         "League Full Name:\t\t"
+            #     ),
+            #     sg.Input(
+            #         default_text=self.league_long_name,
+            #         key="-LG_LONG_NAME-",
+            #         enable_events=True,
+            #         size=(40, 1)
+            #     ),
+            #     sg.Push(),
+            # ],
+            # [
+            #     sg.Text("League Abbreviation:\t"),
+            #     sg.Input(
+            #         default_text=self.league_short_name,
+            #         key="-LG_SHORT_NAME-",
+            #         enable_events=True,
+            #         size=(7, 1)
+            #     ),
+            #     sg.Push(),
+            # ],
             [
                 sg.Text("League Notes:\t\t"),
                 sg.Multiline(
-                    default_text=self.league_notes,
+                    default_text=self.season_notes,
                     key="-LG_NOTES-",
                     enable_events=True,
                     expand_x=True,
-                    size=(40, 5)
+                    size=(40, 5),
                 ),
                 sg.Push(),
             ],
@@ -358,12 +418,11 @@ class LeagueView:
                     default_value=self.field_length,
                     key="-FIELD_LENGTH-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
             [
-
                 sg.Text("Players on field:\t\t"),
                 sg.Combo(
                     values=[x for x in range(5, 20)],
@@ -381,7 +440,7 @@ class LeagueView:
                     default_value=self.downs,
                     key="-DOWNS-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -392,7 +451,7 @@ class LeagueView:
                     default_value=self.first_down_yards,
                     key="-FIRST_DOWN_YARDS-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -403,7 +462,7 @@ class LeagueView:
                     default_value=self.end_zone_length,
                     key="-EZ_LENGTH-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -414,7 +473,7 @@ class LeagueView:
                     default_value=self.kickoff_yardline,
                     key="-KICKOFF_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -425,7 +484,7 @@ class LeagueView:
                     default_value=self.safety_kick_yardline,
                     key="-SAF_KICKOFF_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -436,7 +495,7 @@ class LeagueView:
                     default_value=self.kickoff_touchback_yardline,
                     key="-KICKOFF_TB_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -447,7 +506,7 @@ class LeagueView:
                     default_value=self.punt_touchback_yardline,
                     key="-PUNT_TB_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -458,7 +517,7 @@ class LeagueView:
                     default_value=self.normal_touchback_yardline,
                     key="-NORMAL_TB_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -538,7 +597,7 @@ class LeagueView:
                     default_value=self.pat_yardline,
                     key="-PAT_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -546,14 +605,14 @@ class LeagueView:
                 sg.Checkbox(
                     "Long FG results in bonus point?",
                     key="-LONG_FG_BONUS_POINT-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
                 sg.Checkbox(
                     "An XP is always a kick attempt?",
                     key="-XP_IS_FG-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
@@ -570,7 +629,7 @@ class LeagueView:
                     default_value=self.one_PC_Yardline,
                     key="-1PC_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -581,7 +640,7 @@ class LeagueView:
                     default_value=self.two_PC_Yardline,
                     key="-2PC_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -592,7 +651,7 @@ class LeagueView:
                     default_value=self.three_PC_Yardline,
                     key="-3PC_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -603,7 +662,7 @@ class LeagueView:
                     default_value=self.timeouts_per_half,
                     key="-TIMEOUTS-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -611,10 +670,10 @@ class LeagueView:
                 sg.Text("Minutes per Quarter:\t"),
                 sg.Combo(
                     values=[x for x in range(1, 20)],
-                    default_value=int(self.quarter_seconds/60),
+                    default_value=int(self.quarter_seconds / 60),
                     key="-QUARTER_MINUTES-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -622,10 +681,10 @@ class LeagueView:
                 sg.Text("Minutes per Quarter (OT):\t"),
                 sg.Combo(
                     values=[x for x in range(1, 20)],
-                    default_value=int(self.ot_period_seconds/60),
+                    default_value=int(self.ot_period_seconds / 60),
                     key="-OT_QUARTER_MINUTES-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -657,7 +716,6 @@ class LeagueView:
                     key="-IS_REG_SEASON_OT-",
                     enable_events=True
                 ),
-
             ],
             [
                 sg.Text("Reg. Season OT Type:\t"),
@@ -697,7 +755,7 @@ class LeagueView:
                     default_value=self.ot_periods,
                     key="-OT_QUARTER_MINUTES-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -708,7 +766,7 @@ class LeagueView:
                     default_value=self.ot_periods_until_shootout,
                     key="-OT_PERIODS_UNTIL_SHOOTOUT-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -719,7 +777,7 @@ class LeagueView:
                     default_value=self.min_xfl_ot_periods,
                     key="-MIN_XFL_OT_PERIODS-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -730,7 +788,7 @@ class LeagueView:
                     default_value=self.set_xfl_ot_periods,
                     key="-SET_XFL_OT_PERIODS-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -741,7 +799,7 @@ class LeagueView:
                     default_value=self.kansas_ot_yardline,
                     key="-KANSAS_OT_YARDLINE-",
                     enable_events=True,
-                    size=(10, 5)
+                    size=(10, 5),
                 ),
                 sg.Push(),
             ],
@@ -752,14 +810,14 @@ class LeagueView:
                 sg.Checkbox(
                     "Two Forward Passes?",
                     key="-TWO_FORWARD_PASSES-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
                 sg.Checkbox(
                     "Spikes are team stats?",
                     key="-SPIKES_ARE_TEAM_STATS-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
@@ -773,7 +831,7 @@ class LeagueView:
                 sg.Checkbox(
                     "Sacks are rushes?",
                     key="-KNEELDOWNS_ARE_TEAM_STATS-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
@@ -787,14 +845,14 @@ class LeagueView:
                 sg.Checkbox(
                     "Fair catches on kickoffs always go to touchback line?",
                     key="-KICKOFF_FC_TOUCHBACK_RULE-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
                 sg.Checkbox(
                     "Use XFL kickoff rules?",
                     key="-USE_XFL_KICKOFF-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
@@ -808,14 +866,14 @@ class LeagueView:
                 sg.Checkbox(
                     "Successful drop kick results in bonus point?",
                     key="-DROP_KICK_BONUS_POINT-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
                 sg.Checkbox(
                     "End Zone length is added to Field Goal length?",
                     key="-FG_ADDS_EZ_LENGTH-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
@@ -829,30 +887,29 @@ class LeagueView:
                 sg.Checkbox(
                     "Onside Punting enabled?",
                     key="-ONSIDE_PUNTING_ENABLED-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
                 sg.Checkbox(
                     "Fair Catch enabled?",
                     key="-FAIR_CATCH_ENABLED-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
             [
                 sg.Checkbox(
                     "Special onside play enabled?",
                     key="-SPECIAL_ONSIDE_PLAY_ENABLED-",
-                    enable_events=True
+                    enable_events=True,
                 ),
             ],
-
         ]
 
         layout = [
             [
                 sg.Text(
-                    f"Edit League - {self.league_id}",
+                    f"Edit Season - {self.season} {self.league_id}",
                     font="Arial 24",
                     justification="center",
                     expand_x=True,
@@ -866,57 +923,37 @@ class LeagueView:
             ],
             [
                 sg.TabGroup(
-                    [[
-                        sg.Tab(
-                            "Basics",
-                            lg_basics
-                        ),
-                        sg.Tab(
-                            "Overtime",
-                            ot_layout
-                        ),
-                        sg.Tab(
-                            "Points",
-                            points_layout
-                        ),
-                        sg.Tab(
-                            "Misc.",
-                            misc_layout
-                        )
-
-                    ]],
-                    expand_x=True
-
+                    [
+                        [
+                            sg.Tab("Basics", lg_basics),
+                            sg.Tab("Overtime", ot_layout),
+                            sg.Tab("Points", points_layout),
+                            sg.Tab("Misc.", misc_layout),
+                        ]
+                    ],
+                    expand_x=True,
                 )
             ],
             [
                 sg.Push(),
-                sg.Button(
-                    "OK",
-                    key="-OK_BUTTON-",
-                    size=(10, 1)
-                ),
+                sg.Button("OK", key="-OK_BUTTON-", size=(10, 1)),
                 sg.Button(
                     "Apply",
                     key="-APPLY_BUTTON-",
                     size=(10, 1),
                     disabled=True
                 ),
-                sg.Button(
-                    "Cancel",
-                    key="-CANCEL_BUTTON-",
-                    size=(10, 1)
-                ),
+                sg.Button("Cancel", key="-CANCEL_BUTTON-", size=(10, 1)),
             ],
         ]
 
         window = sg.Window(
-            "About",
+            "Edit Season...",
             layout=layout,
             # size=(500, 600),
             resizable=False,
             finalize=True,
-            keep_on_top=False
+            keep_on_top=False,
         )
 
         window["-IS_PRESEASON_OT-"].update(self.preseason_ot_enabled)
@@ -956,30 +993,15 @@ class LeagueView:
             print(event)
 
             if change_count == 1:
-                window["-APPLY_BUTTON-"].update(
-                    disabled=False
-                )
+                window["-APPLY_BUTTON-"].update(disabled=False)
 
-            if event in (sg.WIN_CLOSED, 'Exit'):
+            if event in (sg.WIN_CLOSED, "Exit"):
                 keep_open = False
             elif event == "-OK_BUTTON-" and (change_count != 0):
                 check_flag = self.changed_settings_check()
                 # print(check_flag)
                 if check_flag == "Yes":
-                    check = safety_check_league_ids(
-                        self.league_id,
-                        self.league_id_original,
-                        self.sqlite3_cur
-                    )
-                    if check == "NOT_CLEAR":
-                        pass
-                    elif check == "ALL_CLEAR":
-                        self.update_league_settings()
-                    else:
-                        raise ValueError(
-                            f"Unhandled error code {check}"
-                        )
-                    del check
+                    self.update_season_settings()
                     keep_open = False
 
                 elif check_flag == "No":
@@ -993,26 +1015,11 @@ class LeagueView:
                 check_flag = self.changed_settings_check()
                 # print(check_flag)
                 if check_flag == "Yes":
-                    check = safety_check_league_ids(
-                        self.league_id,
-                        self.league_id_original,
-                        self.sqlite3_cur
-                    )
-                    if check == "NOT_CLEAR":
-                        pass
-                    elif check == "ALL_CLEAR":
-                        self.update_league_settings()
-                    else:
-                        raise ValueError(
-                            f"Unhandled error code {check}"
-                        )
-                    del check
+                    self.update_season_settings()
                 elif check_flag == "No":
-                    keep_open = False
+                    pass
                 del check_flag
-                window["-APPLY_BUTTON-"].update(
-                    disabled=True
-                )
+                window["-APPLY_BUTTON-"].update(disabled=True)
 
             # if event == "-LG_ID-" and len(values["-LG_ID-"]) > 5:
             #     window["-LG_ID-"].update(values["-LG_ID-"][:-1])
@@ -1037,8 +1044,8 @@ class LeagueView:
                 )
                 change_count += 1
             elif event == "-LG_SHORT_NAME-" and (
-                values["-LG_SHORT_NAME-"] and
-                values["-LG_SHORT_NAME-"][-1] not in (
+                values["-LG_SHORT_NAME-"]
+                and values["-LG_SHORT_NAME-"][-1] not in (
                     self.letters_and_numbers
                 )
             ):
@@ -1048,10 +1055,8 @@ class LeagueView:
                 self.league_id = values["-LG_SHORT_NAME-"]
                 change_count += 1
             elif event == "-LG_SHORT_NAME-" and (
-                values["-LG_SHORT_NAME-"] and
-                values["-LG_SHORT_NAME-"][-1] in (
-                    self.letters_and_numbers
-                )
+                values["-LG_SHORT_NAME-"]
+                and values["-LG_SHORT_NAME-"][-1] in (self.letters_and_numbers)
             ):
                 window["-LG_SHORT_NAME-"].update(
                     values["-LG_SHORT_NAME-"].upper()
@@ -1066,7 +1071,7 @@ class LeagueView:
                 self.league_short_name = values["-LG_SHORT_NAME-"]
                 change_count += 1
             elif event == "-LG_NOTES-":
-                self.league_notes = values["-LG_NOTES-"]
+                self.season_notes = values["-LG_NOTES-"]
                 change_count += 1
             elif event == "-FIELD_LENGTH-":
                 self.field_length = values["-FIELD_LENGTH-"]
@@ -1239,918 +1244,288 @@ class LeagueView:
         window.close()
 
 
-def safety_check_league_ids(
-    league_id: str, league_id_original: str, cur: sqlite3.Cursor
-) -> str:
-    """
-    Validates that if you're changing the league ID,
-    you're not infringing on a league ID that already exists.
-    """
-    sql_script = f"""
-    SELECT DISTINCT
-        league_id
-    FROM fb_leagues
-    WHERE league_id != "{league_id_original}"
-    """
-    lg_id_df = pl.read_database(
-        query=sql_script,
-        connection=cur,
-        schema_overrides={"league_id": pl.String},
-    )
-    if len(lg_id_df) > 0:
-        lg_id_arr = lg_id_df["league_id"].to_list()
-        if league_id in lg_id_arr:
-            sg.popup_error(
-                f"\"{league_id}\" is a league that already exists."
+def new_season_view(settings_json: dict, league_id: str):
+    """ """
+    def check_season_insert(
+        s_df: pl.DataFrame,
+        lg_abv: str,
+        season: int
+    ) -> bool:
+        """
+        Checks if a season already exists for a league.
+
+        """
+        s_df = s_df.filter(
+            (pl.col("league_id") == lg_abv)
+            & (pl.col("season") == season)
+        )
+        if len(s_df) > 0:
+            sg.PopupError(
+                f"There is already a {season} season for {lg_abv}.",
+                title="Season Already Exists Error"
             )
-            return "NOT_CLEAR"
+            return False
+        elif len(s_df) == 0:
+            return True
         else:
-            return "ALL_CLEAR"
-    else:
-        return "ALL_CLEAR"
+            raise RuntimeError(
+                "There is something " +
+                "fundamentally wrong with your computer. \n" +
+                "Restart your computer as soon as possible. \n" +
+                "If this problem persists, consider repairing/replacing " +
+                "the computer you are seeing this error with."
+            )
 
+    def insert_season(season: int, league_id: str) -> bool:
+        # print(season_df.columns)
 
-def new_league_view(settings_json: dict):
-    """
-    """
+        sql_script = """
+        INSERT INTO "fb_seasons"
+        (
+            "season",
+            "league_id",
+            "field_length",
+            "downs",
+            "first_down_yards",
+            "end_zone_length",
+            "kickoff_yardline",
+            "safety_kick_yardline",
+            "kickoff_touchback_yardline",
+            "punt_touchback_yardline",
+            "normal_touchback_yardline",
+            "kansas_ot_yardline",
+            "pat_yardline",
+            "1PC_yardline",
+            "2PC_yardline",
+            "3PC_yardline",
+            "quarters",
+            "timeouts_per_half",
+            "ot_period_seconds",
+            "game_seconds",
+            "half_seconds",
+            "quarter_seconds",
+            "ot_periods",
+            "ot_periods_until_shootout",
+            "min_xfl_ot_periods",
+            "set_xfl_ot_periods",
+            "touchdown_points",
+            "field_goal_points",
+            "safety_points",
+            "pat_points",
+            "pat_defense",
+            "pat_safety",
+            "players_on_field",
+            "xfl_pat",
+            "preseason_ot_enabled",
+            "reg_season_ot_enabled",
+            "postseason_ot_enabled",
+            "preseason_ot_type",
+            "reg_season_ot_type",
+            "postseason_ot_type",
+            "two_forward_passes",
+            "spikes_are_team_stats",
+            "sacks_are_rushes",
+            "kneeldowns_are_team_stats",
+            "kickoff_fc_always_goes_to_touchback",
+            "kickoffs_enabled",
+            "use_xfl_kickoff",
+            "drop_kick_enabled",
+            "drop_kick_bonus_point",
+            "fg_adds_ez_length",
+            "long_fg_bonus_point",
+            "xp_is_a_fg",
+            "rouges_enabled",
+            "punting_enabled",
+            "onside_punts_enabled",
+            "fair_catch_enabled",
+            "special_onside_play_enabled"
+        )
+        SELECT
+            ? as "season",
+            "league_id",
+            "field_length",
+            "downs",
+            "first_down_yards",
+            "end_zone_length",
+            "kickoff_yardline",
+            "safety_kick_yardline",
+            "kickoff_touchback_yardline",
+            "punt_touchback_yardline",
+            "normal_touchback_yardline",
+            "kansas_ot_yardline",
+            "pat_yardline",
+            "1PC_yardline",
+            "2PC_yardline",
+            "3PC_yardline",
+            "quarters",
+            "timeouts_per_half",
+            "ot_period_seconds",
+            "game_seconds",
+            "half_seconds",
+            "quarter_seconds",
+            "ot_periods",
+            "ot_periods_until_shootout",
+            "min_xfl_ot_periods",
+            "set_xfl_ot_periods",
+            "touchdown_points",
+            "field_goal_points",
+            "safety_points",
+            "pat_points",
+            "pat_defense",
+            "pat_safety",
+            "players_on_field",
+            "xfl_pat",
+            "preseason_ot_enabled",
+            "reg_season_ot_enabled",
+            "postseason_ot_enabled",
+            "preseason_ot_type",
+            "reg_season_ot_type",
+            "postseason_ot_type",
+            "two_forward_passes",
+            "spikes_are_team_stats",
+            "sacks_are_rushes",
+            "kneeldowns_are_team_stats",
+            "kickoff_fc_always_goes_to_touchback",
+            "kickoffs_enabled",
+            "use_xfl_kickoff",
+            "drop_kick_enabled",
+            "drop_kick_bonus_point",
+            "fg_adds_ez_length",
+            "long_fg_bonus_point",
+            "xp_is_a_fg",
+            "rouges_enabled",
+            "punting_enabled",
+            "onside_punts_enabled",
+            "fair_catch_enabled",
+            "special_onside_play_enabled"
+
+        FROM "fb_leagues"
+        WHERE ? = "league_id";
+
+        """  # .replace("            ", "")
+
+        try:
+            sqlite3_cur.execute(
+                sql_script,
+                (
+                    season,
+                    league_id,
+                ),
+            )
+            sqlite3_con.commit()
+            return True
+        except sqlite3.IntegrityError:
+            sg.popup_error(
+                "You have already created a league " +
+                f"with a league ID of `{league_id}`.\n" +
+                "Please specify a differient league ID."
+            )
+            return False
+        except Exception as e:
+            logging.warning(
+                f"Unhandled exception `{e}`"
+            )
+            raise e
+
     # Get SQLite3 connections
     sqlite3_con, sqlite3_cur = initialize_sqlite3_connectors()
+    leagues_df = SqliteLoadData.load_leagues(con=sqlite3_con, cur=sqlite3_cur)
+    # leagues_df.drop(["league_long_name", "league_short_name"])
+    seasons_df = SqliteLoadData.load_seasons(con=sqlite3_con, cur=sqlite3_cur)
+
+    leagues_arr = leagues_df["league_id"].to_list()
 
     sg.theme(settings_json["app_theme"])
-    league_id = ""
-    league_long_name = ""
-    letters_and_numbers = "abcdefghijklmnopqrstuvwxyz" +\
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-    base_ruleset_arr = [
-        "AAF",
-        # "Arena",
-        "CFL",
-        "High School",
-        # "NCAA pre-1995",
-        # "NCAA 1996-2018",
-        # "NCAA 2019-2021",
-        # "NCAA 2021-Present",
-        "NCAA",
-        # "NFL pre-1974",
-        # "NFL 1974-1993",
-        # "NFL 1994-2009",
-        # "NFL 2010-2011",
-        # "NFL 2012-2014",
-        # "NFL 2015-2016",
-        # "NFL 2017-2021",
-        # "NFL 2022-2023",
-        # "NFL 2024-Present",
-        "NFL",
-        # "USFL (1982)",
-        # "USFL (2022)",
-        "XFL",
-        # "UFL (2009)",
-        "UFL (2024)"
-    ]
     current_year = datetime.now().year
     latest_season = current_year
     layout = [
         [
             sg.Text(
-                "New League",
+                "New Season",
                 font="Arial 24",
                 justification="center",
                 expand_x=True,
             )
         ],
         [
-            sg.Text(
-                "League ID:\t"
-            ),
-            sg.Input(
-                key="-LG_SHORT_NAME-",
-                enable_events=True,
-                size=(7, 1)
-            ),
-        ],
-        [
-            sg.Text(
-                "League name:\t"
-            ),
-            sg.Input(
-                key="-LG_LONG_NAME-",
-                enable_events=True,
-                size=(40, 1)
-            )
-        ],
-        [
-            sg.Text(
-                "Base ruleset:\t"
-            ),
+            sg.Text("League:\t"),
+            sg.Push(),
             sg.Combo(
-                values=base_ruleset_arr,
-                default_value="NFL",
-                size=(15, 1),
-                key="-BASE_RULESET-",
-                readonly=True
-            )
+                values=leagues_arr,
+                default_value=league_id,
+                key="-LG_ID-",
+                enable_events=True,
+                readonly=True,
+                size=(10, 1)
+            ),
         ],
         [
-            sg.Text(
-                "Latest season:\t"
-            ),
+            sg.Text("Season:\t"),
+            sg.Push(),
             sg.Combo(
-                values=[x for x in range(1900, current_year+5)],
-                default_value=current_year,
-                size=(15, 1),
+                values=[x for x in range(1900, current_year + 5)],
+                default_value=latest_season,
+                size=(10, 1),
+                key="-SEASON-",
                 enable_events=True,
-                key="-LATEST_SEASON-",
-                readonly=True
-            )
+                readonly=True,
+            ),
         ],
         [
             sg.Push(),
             sg.Button(
-                "Create New League",
-                key="-CREATE_NEW_LEAGUE_BUTTON-",
-                enable_events=True
+                "Create New Season",
+                key="-CREATE_NEW_SEASON_BUTTON-",
+                enable_events=True,
             ),
-            sg.Button(
-                "Cancel",
-                key="-CANCEL_BUTTON-",
-                enable_events=True
-            )
-        ]
+            sg.Button("Cancel", key="-CANCEL_BUTTON-", enable_events=True),
+        ],
     ]
 
     window = sg.Window(
-        "About",
+        "New Season...",
         layout=layout,
         # size=(500, 600),
         resizable=False,
         finalize=True,
-        keep_on_top=False
+        keep_on_top=False,
     )
+
     keep_open = True
     while keep_open is True:
         event, values = window.read(timeout=1000)
         print(values)
         print(event)
-        print(league_id)
 
-        # cur.executescript(SqliteSampleFiles.schedule_sql_file())
-        # con.commit()
-
-        if event in (sg.WIN_CLOSED, 'Exit', "-CANCEL_BUTTON-"):
+        if event in (sg.WIN_CLOSED, "Exit", "-CANCEL_BUTTON-"):
             keep_open = False
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "NFL"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "field_length",
-                "downs",
-                "first_down_yards",
-                "end_zone_length",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "kansas_ot_yardline",
-                "pat_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "ot_period_seconds",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "kickoff_fc_always_goes_to_touchback"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                100,
-                4,
-                10,
-                10,
-                35,
-                20,
-                75,
-                80,
-                80,
-                25,
-                15,
-                3,
-                5,
-                10,
-                600,
-                "Modified Sudden Death OT",
-                "Super Modified Sudden Death OT",
-                1
-            );
 
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "field_length",
-                "downs",
-                "first_down_yards",
-                "end_zone_length",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "kansas_ot_yardline",
-                "pat_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "ot_period_seconds",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "kickoff_fc_always_goes_to_touchback"
+        if event == "-LG_SHORT_NAME-" and len(values["-LG_SHORT_NAME-"]) > 5:
+            window["-LG_SHORT_NAME-"].update(values["-LG_SHORT_NAME-"][:-1])
+        elif event == "-SEASON-":
+            latest_season = values["-SEASON-"]
+            print(latest_season)
+        elif event == "-CREATE_NEW_SEASON_BUTTON-":
+            check = check_season_insert(
+                s_df=seasons_df,
+                lg_abv=values["-LG_ID-"],
+                season=latest_season
             )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                100,
-                4,
-                10,
-                10,
-                35,
-                20,
-                75,
-                80,
-                80,
-                25,
-                15,
-                3,
-                5,
-                10,
-                600,
-                "Modified Sudden Death OT",
-                "Super Modified Sudden Death OT",
-                1
-            );
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
+            if check is False:
+                pass
+            else:
+                temp_df = leagues_df.filter(
+                    (pl.col("league_id") == values["-LG_ID-"])
+                )
+                # temp_df["season"] = latest_season
+                temp_df = temp_df.with_columns(
+                    pl.lit(latest_season).alias("season")
+                )
+                insert_season(
+                    season=latest_season,
+                    league_id=values["-LG_ID-"]
+                )
                 keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "NCAA"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "field_length",
-                "downs",
-                "first_down_yards",
-                "end_zone_length",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "kansas_ot_yardline",
-                "pat_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "ot_period_seconds",
-                "preseason_ot_type",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "spikes_are_team_stats",
-                "sacks_are_rushes",
-                "kneeldowns_are_team_stats",
-                "kickoff_fc_always_goes_to_touchback"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                100,
-                4,
-                10,
-                10,
-                35,
-                20,
-                75,
-                80,
-                80,
-                25,
-                3,
-                3,
-                5,
-                10,
-                0,
-                "NCAA OT",
-                "NCAA OT",
-                "NCAA OT",
-                1,
-                1,
-                1,
-                1
-            );
 
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "field_length",
-                "downs",
-                "first_down_yards",
-                "end_zone_length",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "kansas_ot_yardline",
-                "pat_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "ot_period_seconds",
-                "preseason_ot_type",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "spikes_are_team_stats",
-                "sacks_are_rushes",
-                "kneeldowns_are_team_stats",
-                "kickoff_fc_always_goes_to_touchback"
-            )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                100,
-                4,
-                10,
-                10,
-                35,
-                20,
-                75,
-                80,
-                80,
-                25,
-                3,
-                3,
-                5,
-                10,
-                0,
-                "NCAA OT",
-                "NCAA OT",
-                "NCAA OT",
-                1,
-                1,
-                1,
-                1
-            );
-
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
-                keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "CFL"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "field_length",
-                "downs",
-                "first_down_yards",
-                "end_zone_length",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "kansas_ot_yardline",
-                "pat_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "timeouts_per_half",
-                "ot_period_seconds",
-                "fg_adds_ez_length",
-                "rouges_enabled",
-                "onside_punts_enabled",
-                "fair_catch_enabled",
-                "players_on_field"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                110,
-                3,
-                10,
-                20,
-                30,
-                20,
-                85,
-                85,
-                85,
-                35,
-                25,
-                3,
-                3,
-                10,
-                2,
-                0,
-                0,
-                1,
-                1,
-                0,
-                1
-            );
-
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "field_length",
-                "downs",
-                "first_down_yards",
-                "end_zone_length",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "kansas_ot_yardline",
-                "pat_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "timeouts_per_half",
-                "ot_period_seconds",
-                "fg_adds_ez_length",
-                "rouges_enabled",
-                "onside_punts_enabled",
-                "fair_catch_enabled",
-                "players_on_field"
-            )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                110,
-                3,
-                10,
-                20,
-                30,
-                20,
-                85,
-                85,
-                85,
-                35,
-                25,
-                3,
-                3,
-                10,
-                2,
-                0,
-                0,
-                1,
-                1,
-                0,
-                1
-            );
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
-                keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "UFL (2024)"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "ot_period_seconds",
-                "min_xfl_ot_periods",
-                "set_xfl_ot_periods",
-                "xfl_pat",
-                "preseason_ot_type",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "xp_is_a_fg",
-                "special_onside_play_enabled",
-                "use_xfl_kickoff"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                20,
-                20,
-                75,
-                80,
-                80,
-                3,
-                5,
-                10,
-                0,
-                3,
-                1,
-                1,
-                "XFL OT",
-                "XFL OT",
-                "XFL OT",
-                0,
-                1,
-                1
-            );
-
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "kickoff_yardline",
-                "safety_kick_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "ot_period_seconds",
-                "min_xfl_ot_periods",
-                "set_xfl_ot_periods",
-                "xfl_pat",
-                "preseason_ot_type",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "xp_is_a_fg",
-                "special_onside_play_enabled",
-                "use_xfl_kickoff"
-            )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                20,
-                20,
-                75,
-                80,
-                80,
-                3,
-                5,
-                10,
-                0,
-                3,
-                1,
-                1,
-                "XFL OT",
-                "XFL OT",
-                "XFL OT",
-                0,
-                1,
-                1
-            );
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
-                keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "XFL"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "kickoff_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "min_xfl_ot_periods",
-                "set_xfl_ot_periods",
-                "preseason_ot_type",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "two_forward_passes",
-                "use_xfl_kickoff",
-                "special_onside_play_enabled"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                30,
-                65,
-                65,
-                80,
-                3,
-                5,
-                10,
-                3,
-                1,
-                "XFL OT",
-                "XFL OT",
-                "XFL OT",
-                1,
-                1,
-                1
-            );
-
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "kickoff_yardline",
-                "kickoff_touchback_yardline",
-                "punt_touchback_yardline",
-                "normal_touchback_yardline",
-                "1PC_yardline",
-                "2PC_yardline",
-                "3PC_yardline",
-                "min_xfl_ot_periods",
-                "set_xfl_ot_periods",
-                "preseason_ot_type",
-                "reg_season_ot_type",
-                "postseason_ot_type",
-                "two_forward_passes",
-                "use_xfl_kickoff",
-                "special_onside_play_enabled"
-            )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                30,
-                65,
-                65,
-                80,
-                3,
-                5,
-                10,
-                3,
-                1,
-                "XFL OT",
-                "XFL OT",
-                "XFL OT",
-                1,
-                1,
-                1
-            );
-
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
-                keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "AAF"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "kansas_ot_yardline",
-                "ot_period_seconds",
-                "kickoffs_enabled",
-                "xp_is_a_fg",
-                "special_onside_play_enabled"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                10,
-                0,
-                0,
-                0,
-                1
-            );
-
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "kansas_ot_yardline",
-                "ot_period_seconds",
-                "kickoffs_enabled",
-                "xp_is_a_fg",
-                "special_onside_play_enabled"
-            )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                10,
-                0,
-                0,
-                0,
-                1
-            );
-
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
-                keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-        elif event == "-CREATE_NEW_LEAGUE_BUTTON-" and (
-            values["-BASE_RULESET-"] == "High School"
-        ):
-            sql_script = f"""
-            INSERT INTO "fb_leagues"
-            (
-                "league_id",
-                "league_short_name",
-                "league_long_name",
-                "game_seconds",
-                "half_seconds",
-                "quarter_seconds",
-                "sacks_are_rushes",
-                "kneeldowns_are_team_stats"
-            )
-            VALUES
-            (
-                "{league_id}",
-                "{league_id}",
-                "{league_long_name}",
-                -- Not all HS leagues are built the same,
-                -- and I am not building out a ruleset for literally
-                -- every HS league.
-                2880,
-                1440,
-                720,
-                1,
-                1
-            );
-
-            INSERT INTO "fb_seasons"
-            (
-                "season",
-                "league_id",
-                "game_seconds",
-                "half_seconds",
-                "quarter_seconds",
-                "sacks_are_rushes",
-                "kneeldowns_are_team_stats"
-            )
-            VALUES
-            (
-                {latest_season},
-                "{league_id}",
-                2880,
-                1440,
-                720,
-                1,
-                1
-            );
-            """
-            try:
-                sqlite3_cur.executescript(sql_script)
-                sqlite3_con.commit()
-                keep_open = False
-            except sqlite3.IntegrityError:
-                sg.popup_error(
-                    "You have already created a league " +
-                    f"with a league ID of `{league_id}`.\n" +
-                    "Please specify a differient league ID."
-                )
-            except Exception as e:
-                logging.warning(
-                    f"Unhandled exception `{e}`"
-                )
-                raise e
-
-        if event == "-LG_LONG_NAME-":
-            league_long_name = values["-LG_LONG_NAME-"]
-        elif event == "-LG_SHORT_NAME-" and len(
-            values["-LG_SHORT_NAME-"]
-        ) > 5:
-            window["-LG_SHORT_NAME-"].update(
-                values["-LG_SHORT_NAME-"][:-1]
-            )
-        elif event == "-LG_SHORT_NAME-" and (
-            values["-LG_SHORT_NAME-"] and
-            values["-LG_SHORT_NAME-"][-1] not in (
-                letters_and_numbers
-            )
-        ):
-            window["-LG_SHORT_NAME-"].update(
-                values["-LG_SHORT_NAME-"][:-1]
-            )
-            league_id = values["-LG_SHORT_NAME-"]
-        elif event == "-LG_SHORT_NAME-" and (
-            values["-LG_SHORT_NAME-"] and
-            values["-LG_SHORT_NAME-"][-1] in (
-                letters_and_numbers
-            )
-        ):
-            window["-LG_SHORT_NAME-"].update(
-                values["-LG_SHORT_NAME-"].upper()
-            )
-            league_id = values["-LG_SHORT_NAME-"].upper()
-        elif event == "-LATEST_SEASON-":
-            latest_season = values["-LATEST_SEASON-"]
     window.close()

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 """
 - Creation Date: 01/14/2024 4:11 PM EST
-- Last Updated: 03/10/2024 4:35 PM EDT
+- Last Updated: 05/18/2024 02:05 PM EDT
 - Authors: Joseph Armstrong (armstrongjoseph08@gmail.com)
 - file: `./main.py`
 - Purpose: Startup file for "The Football PBP App"
 """
 ###############################################################################
-from core.views.main_window_view import main_window
+from core.views.main_window_view import MainWindow
 
 if __name__ == "__main__":
-    main_window()
+    MainWindow()


### PR DESCRIPTION
- Added a prompt that allows one to create a new season within a football league.
- Added a prompt that allows one to edit a season within an existing football league.
- Implemented `core.embedded.LettersAndNumbers()`, a class with sets of letters, numbers, and/or characters to make it easier to filter out unwanted characters for prompts/inputs in this app.
- Re-implemented all internal SQL scripts to no longer use f-strings.
- Fixed the title within `core.views.edit_league_view.LeagueView` to display `"Edit League..."` instead of `"About"`.
- Fixed the title within `core.views.edit_league_view.new_league_view` to display `"New League..."` instead of `"About"`.
- Fixed the title within `core.views.edit_season_view.SeasonView` to display `"Edit Season..."` instead of `"About"`.
- Fixed an issue within `core.views.edit_league_view.LeagueView` that would allow a user to name a football league with more than the intended 256 characters.
- Renamed `core.views.main_window_view.main_window()` to `core.views.main_window_view.MainWindow()` to better fit this application's naming scheme with classes and functions.
- Fixed a bug within `core.views.main_window_view.MainWindow().refresh_league_seasons()` that would result in the `fb_seasons_df` table to not refresh in every situation `core.views.main_window_view.MainWindow().refresh_league_seasons()` was called.
- Fixed a minor edge case issue in `core.views.main_window_view.MainWindow().refresh_league_seasons()` that would occasionally result in the list of seasons being noticeably out of order.
- Added `"New League"` and `"New League"` buttons to the main window in `core.views.main_window_view.MainWindow()`.
- Fixed a minor edge case in `core.views.main_window_view.MainWindow()` where the window would occasionally forget which league you had previously selected when accessing that league's settings.
- Updated the app version to `0.0.5`